### PR TITLE
Merge update 2022.04.14

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -5,9 +5,30 @@
 # URLs
 # https://rollingrhinoremix.github.io/
 
-# Perform system upgrade
+# Check to see whether the "configuration update", released in 2022.04.14 has been applied.
+if [ ! -f "$HOME/.rhino/updates/configuration" ]; then
+  mkdir ~/.rhino
+  mkdir ~/.rhino/config
+  mkdir ~/.rhino/updates
+  echo "alias alias rhino-config='mkdir ~/.rhino/config/config-script && git clone https://github.com/rollingrhinoremix/rhino-config ~/.rhino/config/config-script/ && sudo bash ~/.rhino/config/config-script/ && rm -rf ~/.rhino/config/config-script'" >> .bashrc
+  touch "$HOME/.rhino/updates/configuration"
+fi
+
+# If the user has selected the option to install the mainline kernel, install it onto the system.
+if [ -f "$HOME/.rhino/config/mainline" ]; then
+  cd ~/rhinoupdate/kernel/
+  wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-headers-5.17.0-051700-generic_5.17.0-051700.202203202130_amd64.deb
+  wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-headers-5.17.0-051700_5.17.0-051700.202203202130_all.deb
+  wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-image-unsigned-5.17.0-051700-generic_5.17.0-051700.202203202130_amd64.deb
+  wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-modules-5.17.0-051700-generic_5.17.0-051700.202203202130_amd64.deb
+  dpkg -i  *.deb
+  sudo apt --fix-broken install
+fi
+
+# Perform full system upgrade
 sudo apt update
 sudo apt dist-upgrade
+
 # Allow the user to know that the upgrade has completed
 echo "---"
 echo "You will need to reboot after the script finishes."

--- a/update.sh
+++ b/update.sh
@@ -6,7 +6,7 @@
 # https://rollingrhinoremix.github.io/
 
 # Check to see whether the "configuration update", released in 2022.04.14 has been applied.
-if [ ! -f "$HOME/.rhino/updates/configuration" ]; then
+if [ ! -f "~/.rhino/updates/configuration" ]; then
   mkdir ~/.rhino
   mkdir ~/.rhino/config
   mkdir ~/.rhino/updates
@@ -15,7 +15,7 @@ if [ ! -f "$HOME/.rhino/updates/configuration" ]; then
 fi
 
 # If the user has selected the option to install the mainline kernel, install it onto the system.
-if [ -f "$HOME/.rhino/config/mainline" ]; then
+if [ -f "~/.rhino/config/mainline" ]; then
   cd ~/rhinoupdate/kernel/
   wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-headers-5.17.0-051700-generic_5.17.0-051700.202203202130_amd64.deb
   wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-headers-5.17.0-051700_5.17.0-051700.202203202130_all.deb

--- a/update.sh
+++ b/update.sh
@@ -5,17 +5,21 @@
 # URLs
 # https://rollingrhinoremix.github.io/
 
+# Due to current issues in rhino-update, the command will be removed from .bashrc and then readded when rhino-update is ran. This is due to an error created when the script is ran as sudo when it should not have been, issues have only arisen after if statements were created. 
+sed -i '/alias rhino-update"/d' ~/.bashrc
+echo "alias rhino-update='mkdir ~/rhinoupdate && mkdir ~/rhinoupdate/kernel && mkdir ~/rhinoupdate/script/ && git clone https://github.com/rollingrhinoremix/rhino-update ~/rhinoupdate/script && bash ~/rhinoupdate/script/update.sh && rm -rf ~/rhinoupdate'" >> ~/.bashrc
+
 # Check to see whether the "configuration update", released in 2022.04.14 has been applied.
-if [ ! -f "~/.rhino/updates/configuration" ]; then
+if [ ! -f "$HOME/.rhino/updates/configuration" ]; then
   mkdir ~/.rhino
   mkdir ~/.rhino/config
   mkdir ~/.rhino/updates
-  echo "alias rhino-config='mkdir ~/.rhino/config/config-script && git clone https://github.com/rollingrhinoremix/rhino-config ~/.rhino/config/config-script/ && python3 ~/.rhino/config/config-script/config.py && rm -rf ~/.rhino/config/config-script'" >> .bashrc
+  echo "alias rhino-config='mkdir ~/.rhino/config/config-script && git clone https://github.com/rollingrhinoremix/rhino-config ~/.rhino/config/config-script/ && python3 ~/.rhino/config/config-script/config.py && rm -rf ~/.rhino/config/config-script'" >> ~/.bashrc
   touch "$HOME/.rhino/updates/configuration"
 fi
 
 # If the user has selected the option to install the mainline kernel, install it onto the system.
-if [ -f "~/.rhino/config/mainline" ]; then
+if [ -f "$HOME/.rhino/config/mainline" ]; then
   cd ~/rhinoupdate/kernel/
   wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-headers-5.17.0-051700-generic_5.17.0-051700.202203202130_amd64.deb
   wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-headers-5.17.0-051700_5.17.0-051700.202203202130_all.deb

--- a/update.sh
+++ b/update.sh
@@ -5,10 +5,6 @@
 # URLs
 # https://rollingrhinoremix.github.io/
 
-# Due to current issues in rhino-update, the command will be removed from .bashrc and then readded when rhino-update is ran. This is due to an error created when the script is ran as sudo when it should not have been, issues have only arisen after if statements were created. 
-sed -i '/alias rhino-update"/d' ~/.bashrc
-echo "alias rhino-update='mkdir ~/rhinoupdate && mkdir ~/rhinoupdate/kernel && mkdir ~/rhinoupdate/script/ && git clone https://github.com/rollingrhinoremix/rhino-update ~/rhinoupdate/script && bash ~/rhinoupdate/script/update.sh && rm -rf ~/rhinoupdate'" >> ~/.bashrc
-
 # Check to see whether the "configuration update", released in 2022.04.14 has been applied.
 if [ ! -f "$HOME/.rhino/updates/configuration" ]; then
   mkdir ~/.rhino

--- a/update.sh
+++ b/update.sh
@@ -7,9 +7,9 @@
 
 # Check to see whether the "configuration update", released in 2022.04.14 has been applied.
 if [ ! -f "$HOME/.rhino/updates/configuration" ]; then
-  sudo mkdir ~/.rhino
-  sudo mkdir ~/.rhino/config
-  sudo mkdir ~/.rhino/updates
+  mkdir ~/.rhino
+  mkdir ~/.rhino/config
+  mkdir ~/.rhino/updates
   echo "alias rhino-config='mkdir ~/.rhino/config/config-script && git clone https://github.com/rollingrhinoremix/rhino-config ~/.rhino/config/config-script/ && python3 ~/.rhino/config/config-script/config.py && rm -rf ~/.rhino/config/config-script'" >> .bashrc
   touch "$HOME/.rhino/updates/configuration"
 fi
@@ -17,10 +17,10 @@ fi
 # If the user has selected the option to install the mainline kernel, install it onto the system.
 if [ -f "$HOME/.rhino/config/mainline" ]; then
   cd ~/rhinoupdate/kernel/
-  sudo wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-headers-5.17.0-051700-generic_5.17.0-051700.202203202130_amd64.deb
-  sudo wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-headers-5.17.0-051700_5.17.0-051700.202203202130_all.deb
-  sudo wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-image-unsigned-5.17.0-051700-generic_5.17.0-051700.202203202130_amd64.deb
-  sudo wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-modules-5.17.0-051700-generic_5.17.0-051700.202203202130_amd64.deb
+  wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-headers-5.17.0-051700-generic_5.17.0-051700.202203202130_amd64.deb
+  wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-headers-5.17.0-051700_5.17.0-051700.202203202130_all.deb
+  wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-image-unsigned-5.17.0-051700-generic_5.17.0-051700.202203202130_amd64.deb
+  wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-modules-5.17.0-051700-generic_5.17.0-051700.202203202130_amd64.deb
   sudo dpkg -i  *.deb
   sudo apt --fix-broken install
 fi

--- a/update.sh
+++ b/update.sh
@@ -10,7 +10,7 @@ if [ ! -f "$HOME/.rhino/updates/configuration" ]; then
   mkdir ~/.rhino
   mkdir ~/.rhino/config
   mkdir ~/.rhino/updates
-  echo "alias alias rhino-config='mkdir ~/.rhino/config/config-script && git clone https://github.com/rollingrhinoremix/rhino-config ~/.rhino/config/config-script/ && sudo bash ~/.rhino/config/config-script/ && rm -rf ~/.rhino/config/config-script'" >> .bashrc
+  echo "alias rhino-config='mkdir ~/.rhino/config/config-script && git clone https://github.com/rollingrhinoremix/rhino-config ~/.rhino/config/config-script/ && python3 ~/.rhino/config/config-script/config.py && rm -rf ~/.rhino/config/config-script'" >> .bashrc
   touch "$HOME/.rhino/updates/configuration"
 fi
 

--- a/update.sh
+++ b/update.sh
@@ -7,9 +7,9 @@
 
 # Check to see whether the "configuration update", released in 2022.04.14 has been applied.
 if [ ! -f "$HOME/.rhino/updates/configuration" ]; then
-  mkdir ~/.rhino
-  mkdir ~/.rhino/config
-  mkdir ~/.rhino/updates
+  sudo mkdir ~/.rhino
+  sudo mkdir ~/.rhino/config
+  sudo mkdir ~/.rhino/updates
   echo "alias rhino-config='mkdir ~/.rhino/config/config-script && git clone https://github.com/rollingrhinoremix/rhino-config ~/.rhino/config/config-script/ && python3 ~/.rhino/config/config-script/config.py && rm -rf ~/.rhino/config/config-script'" >> .bashrc
   touch "$HOME/.rhino/updates/configuration"
 fi
@@ -17,11 +17,11 @@ fi
 # If the user has selected the option to install the mainline kernel, install it onto the system.
 if [ -f "$HOME/.rhino/config/mainline" ]; then
   cd ~/rhinoupdate/kernel/
-  wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-headers-5.17.0-051700-generic_5.17.0-051700.202203202130_amd64.deb
-  wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-headers-5.17.0-051700_5.17.0-051700.202203202130_all.deb
-  wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-image-unsigned-5.17.0-051700-generic_5.17.0-051700.202203202130_amd64.deb
-  wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-modules-5.17.0-051700-generic_5.17.0-051700.202203202130_amd64.deb
-  dpkg -i  *.deb
+  sudo wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-headers-5.17.0-051700-generic_5.17.0-051700.202203202130_amd64.deb
+  sudo wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-headers-5.17.0-051700_5.17.0-051700.202203202130_all.deb
+  sudo wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-image-unsigned-5.17.0-051700-generic_5.17.0-051700.202203202130_amd64.deb
+  sudo wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17/amd64/linux-modules-5.17.0-051700-generic_5.17.0-051700.202203202130_amd64.deb
+  sudo dpkg -i  *.deb
   sudo apt --fix-broken install
 fi
 


### PR DESCRIPTION
// DO NOT MERGE UNTIL APRIL 14TH 2022

Update 2022.04.14 will provide the ability to configure rhino with the rhino-config command, this update will allow for the rhino-config command to work and allow rhino-update to read the changes and work as intended.