### PR TITLE
full-upgrade instead of dist-upgrade

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -7,7 +7,7 @@
 
 # Perform full system upgrade
 sudo apt update
-sudo apt dist-upgrade
+sudo apt full-upgrade
 
 # Allow the user to know that the upgrade has completed
 echo "---"


### PR DESCRIPTION
Hi,

we should be using "apt full-upgrade" instead of "apt dist-upgrade".
apt dist-upgrade is just an alias and in fact launches apt-**get** dist-upgrade.

They both do the exact same thing (see this for reference: https://askubuntu.com/a/1316448) so there is nothing wrong with it in the current state.
But by using apt full-upgrade we're staying in the correct apt syntax.

Nice project btw. Currently testing it in a Vm. :)
Cheers! 