### PR TITLE
hotfix: swap dpkg and apt

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -21,8 +21,7 @@ if [[ -f "$HOME/.rhino/config/mainline" ]]; then
   wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.3/amd64/linux-headers-5.17.3-051703_5.17.3-051703.202204131853_all.deb
   wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.3/amd64/linux-image-unsigned-5.17.3-051703-generic_5.17.3-051703.202204131853_amd64.deb
   wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.3/amd64/linux-modules-5.17.3-051703-generic_5.17.3-051703.202204131853_amd64.deb
-  sudo dpkg -i *.deb
-  sudo apt --fix-broken install
+  sudo apt install ./*.deb
 fi
 
 # If snapd is installed.
@@ -36,8 +35,7 @@ if [[ -f "$HOME/.rhino/config/pacstall" ]]; then
   mkdir -p ~/rhinoupdate/pacstall/
   cd ~/rhinoupdate/pacstall/
   wget -q --show-progress --progress=bar:force https://github.com/pacstall/pacstall/releases/download/1.7.3/pacstall-1.7.3.deb
-  sudo dpkg -i *.deb
-  sudo apt --fix-broken install
+  sudo apt install ./*.deb
   pacstall -Up
 fi
 


### PR DESCRIPTION
dpkg fails to install deps, which means that dpkg will have a non-zero exit code, and `set -e` will fail the entire script.