### PR TITLE
feat(update.sh): [Don’t update kernel if kernel version is already installed]

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -32,14 +32,14 @@ rm -rf ~/rhino-config
 
 # If the user has selected the option to install the mainline kernel, install it onto the system.
 if [[ -f "$HOME/.rhino/config/mainline" ]]; then
-  if [[ ! -f "$HOME/.rhino/config/5.17.5" ]]; then
+  if [[ ! -f "$HOME/.rhino/config/5-17-5" ]]; then
     cd ~/rhinoupdate/kernel/
     wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.5/amd64/linux-headers-5.17.5-051705-generic_5.17.5-051705.202204271406_amd64.deb
     wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.5/amd64/linux-headers-5.17.5-051705_5.17.5-051705.202204271406_all.deb
     wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.5/amd64/linux-image-unsigned-5.17.5-051705-generic_5.17.5-051705.202204271406_amd64.deb
     wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.5/amd64/linux-modules-5.17.5-051705-generic_5.17.5-051705.202204271406_amd64.deb
     sudo apt install ./*.deb
-    : > "$HOME/.rhino/config/5.17.5"
+    : > "$HOME/.rhino/config/5-17-5"
   fi
 fi
 

--- a/update.sh
+++ b/update.sh
@@ -32,12 +32,15 @@ rm -rf ~/rhino-config
 
 # If the user has selected the option to install the mainline kernel, install it onto the system.
 if [[ -f "$HOME/.rhino/config/mainline" ]]; then
-  cd ~/rhinoupdate/kernel/
-  wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.5/amd64/linux-headers-5.17.5-051705-generic_5.17.5-051705.202204271406_amd64.deb
-  wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.5/amd64/linux-headers-5.17.5-051705_5.17.5-051705.202204271406_all.deb
-  wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.5/amd64/linux-image-unsigned-5.17.5-051705-generic_5.17.5-051705.202204271406_amd64.deb
-  wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.5/amd64/linux-modules-5.17.5-051705-generic_5.17.5-051705.202204271406_amd64.deb
-  sudo apt install ./*.deb
+  if [[ ! -f "$HOME/.rhino/config/5.17.5" ]]; then
+    cd ~/rhinoupdate/kernel/
+    wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.5/amd64/linux-headers-5.17.5-051705-generic_5.17.5-051705.202204271406_amd64.deb
+    wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.5/amd64/linux-headers-5.17.5-051705_5.17.5-051705.202204271406_all.deb
+    wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.5/amd64/linux-image-unsigned-5.17.5-051705-generic_5.17.5-051705.202204271406_amd64.deb
+    wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.5/amd64/linux-modules-5.17.5-051705-generic_5.17.5-051705.202204271406_amd64.deb
+    sudo apt install ./*.deb
+    : > "$HOME/.rhino/config/5.17.5"
+  fi
 fi
 
 # If snapd is installed.
@@ -61,5 +64,4 @@ fi
 
 # Allow the user to know that the upgrade has completed.
 echo "---
-The upgrade has been completed. Please reboot your system to see the changes.
----"
+The upgrade has been completed. Please reboot your system to see the changes.---"

--- a/update.sh
+++ b/update.sh
@@ -64,4 +64,5 @@ fi
 
 # Allow the user to know that the upgrade has completed.
 echo "---
-The upgrade has been completed. Please reboot your system to see the changes.---"
+The upgrade has been completed. Please reboot your system to see the changes.
+---"


### PR DESCRIPTION
This will make it so that when the update is called it will check for the existence of 5.17.5 in the config files as an identifier for the kernel and if this identifier is found the kernel will not be installed due to it being installed already 