### PR TITLE
fix(update.sh): Fix dependency error with Pacstall

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -51,12 +51,19 @@ fi
 
 # If Pacstall has been enabled
 if [[ -f "$HOME/.rhino/config/pacstall" ]]; then
-  echo "Pacstall has been disabled due to an issue with Ubuntu dependencies, and will be re-enabled at a later date."
-  #mkdir -p ~/rhinoupdate/pacstall/
-  #cd ~/rhinoupdate/pacstall/
-  #wget -q --show-progress --progress=bar:force https://github.com/pacstall/pacstall/releases/download/1.7.3/pacstall-1.7.3.deb
-  #sudo apt install ./*.deb
-  #pacstall -Up
+# Check to see whether an issue in Curl has been fixed
+  if [[ ! -f "$HOME/.rhino/config/curl-fix" ]]; then
+    sudo apt remove libcurl4 -y
+    sudo apt autoremove -y 
+    sudo apt install libcurl4 curl -y
+    : > "$HOME/.rhino/config/curl-fix"
+  fi
+  # Install Pacstall
+  mkdir -p ~/rhinoupdate/pacstall/
+  cd ~/rhinoupdate/pacstall/
+  wget -q --show-progress --progress=bar:force https://github.com/pacstall/pacstall/releases/download/1.7.3/pacstall-1.7.3.deb
+  sudo apt install ./*.deb
+  pacstall -Up
 fi
 
 # Perform full system upgrade.


### PR DESCRIPTION
The version libcurl4 Ubuntu comes preinstalled with does not seem to work with Pacstall, however when reinstalled it works perfectly fine, and so this fixes that issue.
