### PR TITLE
feat(update.sh): use FHS directories

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -8,30 +8,30 @@
 set -e
 
 # Check to see whether the "configuration update", released in 2022.04.19 has been applied.
-if [[ ! -f "$HOME/.rhino/updates/configuration" ]]; then
-  mkdir -p ~/.rhino/{config,updates}
-  echo "alias rhino-config='mkdir ~/.rhino/config/config-script && git clone https://github.com/rollingrhinoremix/rhino-config ~/.rhino/config/config-script/ && python3 ~/.rhino/config/config-script/config.py && rm -rf ~/.rhino/config/config-script'" >> ~/.bashrc
-  : > "$HOME/.rhino/updates/configuration"
+if [[ ! -f "/usr/share/rhino/updates/configuration" ]]; then
+  mkdir -p /usr/share/rhino/{config,updates}
+  echo "alias rhino-config='mkdir /usr/share/rhino/config/config-script && git clone https://github.com/rollingrhinoremix/rhino-config /usr/share/rhino/config/config-script/ && python3 /usr/share/rhino/config/config-script/config.py && rm -rf /usr/share/rhino/config/config-script'" >> ~/.bashrc
+  : > "/usr/share/rhino/updates/configuration"
 fi
 
 # Check to see whether the rhino-config v2 update has been applied, which converts Rhino into a command-line utility.
-if [[ ! -f "$HOME/.rhino/updates/config-v2" ]]; then
-  mkdir ~/rhinoupdate/distro
-  git clone https://github.com/rollingrhinoremix/distro ~/rhinoupdate/distro
-  mv ~/rhinoupdate/distro/.{bashrc,bash_aliases} ~
-  : > "$HOME/.rhino/updates/config-v2"
+if [[ ! -f "/usr/share/rhino/updates/config-v2" ]]; then
+  mkdir /usr/share/rhino/rhinoupdate/distro
+  git clone https://github.com/rollingrhinoremix/distro /usr/share/rhino/rhinoupdate/distro
+  mv /usr/share/rhino/rhinoupdate/distro/.{bashrc,bash_aliases} ~
+  : > "/usr/share/rhino/updates/config-v2"
 fi
 
 # Install latest rhino-config utility
-mkdir ~/rhino-config
-cd ~/rhino-config
+mkdir /usr/share/rhino/rhino-config
+cd /usr/share/rhino/rhino-config
 wget -q --show-progress --progress=bar:force https://github.com/rollingrhinoremix/rhino-config/releases/download/v2.0.1/rhino-config
 chmod +x rhino-config
 sudo mv rhino-config /usr/bin
-rm -rf ~/rhino-config
+rm -rf /usr/share/rhino/rhino-config
 
 # If the user has selected the option to install the mainline kernel, install it onto the system.
-if [[ -f "$HOME/.rhino/config/mainline" ]] && [[ ! -f "$HOME/.rhino/config/5-18-0" ]]; then
+if [[ -f "/usr/share/rhino/config/mainline" ]] && [[ ! -f "/usr/share/rhino/config/5-18-0" ]]; then
     cd ~/rhinoupdate/kernel/
     wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.18/amd64/CHECKSUMS
     wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.18/amd64/linux-headers-5.18.0-051800-generic_5.18.0-051800.202205222030_amd64.deb
@@ -42,7 +42,7 @@ if [[ -f "$HOME/.rhino/config/mainline" ]] && [[ ! -f "$HOME/.rhino/config/5-18-
     echo "Verifying checksums..."
     if shasum --check --ignore-missing CHECKSUMS; then
       sudo apt install ./*.deb
-      : > "$HOME/.rhino/config/5-18-0"
+      : > "/usr/share/rhino/config/5-18-0"
     else
       >&2 echo "Failed to verify checksums of downloaded kernel files!"
       exit 1
@@ -50,23 +50,23 @@ if [[ -f "$HOME/.rhino/config/mainline" ]] && [[ ! -f "$HOME/.rhino/config/5-18-
 fi
 
 # If snapd is installed.
-if [[ ! -f "$HOME/.rhino/config/snapdpurge" ]]; then
+if [[ ! -f "/usr/share/rhino/config/snapdpurge" ]]; then
   sudo snap refresh
 fi
 
 
 # If Pacstall has been enabled
-if [[ -f "$HOME/.rhino/config/pacstall" ]]; then
+if [[ -f "/usr/share/rhino/config/pacstall" ]]; then
 # Check to see whether an issue in Curl has been fixed
-  if [[ ! -f "$HOME/.rhino/config/curl-fix" ]]; then
+  if [[ ! -f "/usr/share/rhino/config/curl-fix" ]]; then
     sudo apt remove libcurl4 -y
     sudo apt autoremove -y 
     sudo apt install libcurl4 curl -y
-    : > "$HOME/.rhino/config/curl-fix"
+    : > "/usr/share/rhino/config/curl-fix"
   fi
   # Install Pacstall
-  mkdir -p ~/rhinoupdate/pacstall/
-  cd ~/rhinoupdate/pacstall/
+  mkdir -p /usr/share/rhino/rhinoupdate/pacstall/
+  cd /usr/share/rhino/rhinoupdate/pacstall/
   wget -q --show-progress --progress=bar:force https://github.com/pacstall/pacstall/releases/download/1.7.3/pacstall-1.7.3.deb
   sudo apt install ./*.deb
   pacstall -Up

--- a/update.sh
+++ b/update.sh
@@ -17,13 +17,6 @@ elif [ "$(git rev-parse @)" = "$(git merge-base @ main)" ]; then
     exit 0
 fi
 
-# Check to see whether the "configuration update", released in 2022.04.19 has been applied.
-if [[ ! -f "/usr/share/rhino/updates/configuration" ]]; then
-  mkdir -p /usr/share/rhino/{config,updates}
-  echo "alias rhino-config='mkdir /usr/share/rhino/config/config-script && git clone https://github.com/rollingrhinoremix/rhino-config /usr/share/rhino/config/config-script/ && python3 /usr/share/rhino/config/config-script/config.py && rm -rf /usr/share/rhino/config/config-script'" >> ~/.bashrc
-  : > "/usr/share/rhino/updates/configuration"
-fi
-
 # Check to see whether Nala is installed.
 if [[ ! -f "/usr/share/rhino/updates/nala" ]]; then
   sudo apt install nala -y

--- a/update.sh
+++ b/update.sh
@@ -7,6 +7,14 @@
 
 set -e
 
+# Check whether there is a newer version of this script
+cd /usr/rhino/rhino-updater
+if /usr/bin/git pull; then
+    chmod +x /usr/rhino/rhino-updater/update.sh
+    exec /usr/bin/rhino-update
+    exit $?
+fi
+
 # Check to see whether the "configuration update", released in 2022.04.19 has been applied.
 if [[ ! -f "/usr/share/rhino/updates/configuration" ]]; then
   mkdir -p /usr/share/rhino/{config,updates}

--- a/update.sh
+++ b/update.sh
@@ -24,14 +24,6 @@ if [[ ! -f "/usr/share/rhino/updates/configuration" ]]; then
   : > "/usr/share/rhino/updates/configuration"
 fi
 
-# Check to see whether the rhino-config v2 update has been applied, which converts Rhino into a command-line utility.
-if [[ ! -f "/usr/share/rhino/updates/config-v2" ]]; then
-  mkdir /usr/share/rhino/rhinoupdate/distro
-  git clone https://github.com/rollingrhinoremix/distro /usr/share/rhino/rhinoupdate/distro
-  mv /usr/share/rhino/rhinoupdate/distro/.{bashrc,bash_aliases} ~
-  : > "/usr/share/rhino/updates/config-v2"
-fi
-
 # Check to see whether Nala is installed.
 if [[ ! -f "/usr/share/rhino/updates/nala" ]]; then
   sudo apt install nala -y

--- a/update.sh
+++ b/update.sh
@@ -30,6 +30,14 @@ chmod +x rhino-config
 sudo mv rhino-config /usr/bin
 rm -rf /usr/share/rhino/rhino-config
 
+# Install latest rhino-deinst utility
+mkdir /usr/share/rhino/rhino-deinst
+cd /usr/share/rhino/rhino-deinst
+wget -q --show-progress --progress=bar:force https://github.com/rollingrhinoremix/rhino-deinst/releases/latest/download/rhino-deinst
+chmod +x rhino-deinst
+sudo mv rhino-deinst /usr/bin
+rm -rf /usr/share/rhino/rhino-deinst
+
 # If the user has selected the option to install the mainline kernel, install it onto the system.
 if [[ -f "/usr/share/rhino/config/mainline" ]] && [[ ! -f "/usr/share/rhino/config/5-18-0" ]]; then
     cd /usr/share//rhinoupdate/kernel/
@@ -72,7 +80,7 @@ if [[ -f "/usr/share/rhino/config/pacstall" ]]; then
   pacstall -Up
 fi
 
-chmod -R 777 /usr/share/rhino
+chmod -R 775 /usr/share/rhino
 
 # Perform full system upgrade.
 { sudo apt update 2> /dev/null; sudo apt dist-upgrade 2> /dev/null; }

--- a/update.sh
+++ b/update.sh
@@ -32,9 +32,9 @@ if [[ ! -f "/usr/share/rhino/updates/config-v2" ]]; then
 fi
 
 # Check to see whether Nala is installed.
-if [[ ! -f "$HOME/.rhino/updates/nala" ]]; then
+if [[ ! -f "/usr/share/rhino/updates/nala" ]]; then
   sudo apt install nala -y
-  : > "$HOME/.rhino/updates/nala"
+  : > "/usr/share/rhino/updates/nala"
 fi
 
 # Install latest rhino-config utility
@@ -53,7 +53,7 @@ chmod +x rhino-deinst
 sudo mv rhino-deinst /usr/bin
 
 # Automatically install the latest Linux kernel onto the system if it has not been installed already.
-if [[ ! -f "/usr/share/.rhino/config/5-18-11" ]]; then
+if [[ ! -f "/usr/share/rhino/config/5-18-11" ]]; then
     cd ~/rhinoupdate/kernel/
     wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.18.11/amd64/CHECKSUMS &
     wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.18.11/amd64/linux-headers-5.18.11-051811-generic_5.18.11-051811.202207121541_amd64.deb &
@@ -65,7 +65,7 @@ if [[ ! -f "/usr/share/.rhino/config/5-18-11" ]]; then
     echo "Verifying checksums..."
     if shasum --check --ignore-missing CHECKSUMS; then
       sudo apt install ./*.deb
-      : > "/usr/share/.rhino/config/5-18-11"
+      : > "/usr/share/rhino/config/5-18-11"
     else
       >&2 echo "Failed to verify checksums of downloaded kernel files!"
       exit 1
@@ -73,14 +73,14 @@ if [[ ! -f "/usr/share/.rhino/config/5-18-11" ]]; then
 fi
 
 # If the user has enabled the xanmod kernel via rhino-config, install it.
-if [[ -f "$HOME/.rhino/config/xanmod" ]]; then
+if [[ -f "/usr/share/rhino/config/xanmod" ]]; then
     echo 'deb http://deb.xanmod.org releases main' | sudo tee /etc/apt/sources.list.d/xanmod-kernel.list
     wget -qO - https://dl.xanmod.org/gpg.key | sudo apt-key --keyring /etc/apt/trusted.gpg.d/xanmod-kernel.gpg add -
     sudo apt update && sudo apt install linux-xanmod
 fi
 
 # If the user has enabled the liq kernel via rhino-config, install it.
-if [[ -f "$HOME/.rhino/config/liquorix" ]]; then
+if [[ -f "/usr/share/rhino/config/liquorix" ]]; then
    sudo add-apt-repository ppa:damentz/liquorix && sudo apt-get update
    sudo apt install linux-image-liquorix-amd64 linux-headers-liquorix-amd64
 fi

--- a/update.sh
+++ b/update.sh
@@ -8,12 +8,13 @@
 
 set -e
 
-# Check whether there is a newer version of this script
-cd /usr/share/rhino/rhino-update
-if git pull; then
+if [ "$(git rev-parse @)" = "$(git rev-parse main)" ]; then
+    true
+elif [ "$(git rev-parse @)" = "$(git merge-base @ main)" ]; then
+    git pull
     chmod +x /usr/share/rhino/rhino-update/update.sh
-    exec /usr/bin/rhino-update
-    exit $?
+    exec /usr/bin/rhino-update &
+    exit 0
 fi
 
 # Check to see whether the "configuration update", released in 2022.04.19 has been applied.

--- a/update.sh
+++ b/update.sh
@@ -111,6 +111,7 @@ cd /usr/share/rhino
 mkdir /usr/share/rhino/rhinoupdate/system-files/
 git clone https://github.com/rollingrhinoremix/assets /usr/share/rhino/rhinoupdate/system-files/
 sudo mv /usr/share/rhino/rhinoupdate/system-files/os-release /usr/lib/
+chmod -R 775 /usr/share/rhino # In case this was ran with root - for regular users
 
 # Allow the user to know that the upgrade has completed.
 echo "---

--- a/update.sh
+++ b/update.sh
@@ -32,7 +32,7 @@ rm -rf /usr/share/rhino/rhino-config
 
 # If the user has selected the option to install the mainline kernel, install it onto the system.
 if [[ -f "/usr/share/rhino/config/mainline" ]] && [[ ! -f "/usr/share/rhino/config/5-18-0" ]]; then
-    cd ~/rhinoupdate/kernel/
+    cd /usr/share//rhinoupdate/kernel/
     wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.18/amd64/CHECKSUMS
     wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.18/amd64/linux-headers-5.18.0-051800-generic_5.18.0-051800.202205222030_amd64.deb
     wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.18/amd64/linux-headers-5.18.0-051800_5.18.0-051800.202205222030_all.deb
@@ -71,6 +71,8 @@ if [[ -f "/usr/share/rhino/config/pacstall" ]]; then
   sudo apt install ./*.deb
   pacstall -Up
 fi
+
+chmod -R 777 /usr/share/rhino
 
 # Perform full system upgrade.
 { sudo apt update 2> /dev/null; sudo apt dist-upgrade 2> /dev/null; }

--- a/update.sh
+++ b/update.sh
@@ -30,14 +30,6 @@ chmod +x rhino-config
 sudo mv rhino-config /usr/bin
 rm -rf /usr/share/rhino/rhino-config
 
-# Install latest rhino-deinst utility
-mkdir /usr/share/rhino/rhino-deinst
-cd /usr/share/rhino/rhino-deinst
-wget -q --show-progress --progress=bar:force https://github.com/rollingrhinoremix/rhino-deinst/releases/latest/download/rhino-deinst
-chmod +x rhino-deinst
-sudo mv rhino-deinst /usr/bin
-rm -rf /usr/share/rhino/rhino-deinst
-
 # If the user has selected the option to install the mainline kernel, install it onto the system.
 if [[ -f "/usr/share/rhino/config/mainline" ]] && [[ ! -f "/usr/share/rhino/config/5-18-0" ]]; then
     cd /usr/share//rhinoupdate/kernel/

--- a/update.sh
+++ b/update.sh
@@ -31,8 +31,8 @@ sudo mv rhino-config /usr/bin
 rm -rf /usr/share/rhino/rhino-config
 
 # Install the latest rhino-deinst utility
-mkdir ~/rhinoupdate/rhino-deinst
-cd ~/rhinoupdate/rhino-deinst
+mkdir /usr/share/rhino/rhinoupdate/rhino-deinst
+cd /usr/share/rhino/rhinoupdate/rhino-deinst
 wget -q --show-progress --progress=bar:force https://github.com/rollingrhinoremix/rhino-deinst/releases/latest/download/rhino-deinst
 chmod +x rhino-deinst
 sudo mv rhino-deinst /usr/bin
@@ -84,11 +84,11 @@ chmod -R 775 /usr/share/rhino
 { sudo apt update 2> /dev/null; sudo apt dist-upgrade 2> /dev/null; }
 
 # Install/Fix system files such as /etc/os-release
-cd ~
-mkdir ~/rhinoupdate/system-files/
-git clone https://github.com/rollingrhinoremix/assets ~/rhinoupdate/system-files/
+cd /usr/share/rhino
+mkdir /usr/share/rhino/rhinoupdate/system-files/
+git clone https://github.com/rollingrhinoremix/assets /usr/share/rhino/rhinoupdate/system-files/
 sudo rm -rf /etc/os-release
-sudo mv ~/rhinoupdate/system-files/os-release /etc/
+sudo mv /usr/share/rhino/rhinoupdate/system-files/os-release /etc/
 
 # Allow the user to know that the upgrade has completed.
 echo "---

--- a/update.sh
+++ b/update.sh
@@ -86,8 +86,6 @@ if [[ -f "/usr/share/rhino/config/pacstall" ]]; then
   fi
 fi
 
-chmod -R 775 /usr/share/rhino
-
 # Perform full system upgrade.
 { sudo apt update 2> /dev/null; sudo apt dist-upgrade 2> /dev/null; }
 
@@ -97,6 +95,7 @@ mkdir /usr/share/rhino/rhinoupdate/system-files/
 git clone https://github.com/rollingrhinoremix/assets /usr/share/rhino/rhinoupdate/system-files/
 sudo rm -rf /etc/os-release
 sudo mv /usr/share/rhino/rhinoupdate/system-files/os-release /etc/
+chmod -R 775 /usr/share/rhino # In case this was ran with root - for regular users
 
 # Allow the user to know that the upgrade has completed.
 echo "---

--- a/update.sh
+++ b/update.sh
@@ -9,9 +9,9 @@
 set -e
 
 # Check whether there is a newer version of this script
-cd /usr/rhino/rhino-updater
-if /usr/bin/git pull; then
-    chmod +x /usr/rhino/rhino-updater/update.sh
+cd /usr/share/rhino/rhino-update
+if git pull; then
+    chmod +x /usr/share/rhino/rhino-update/update.sh
     exec /usr/bin/rhino-update
     exit $?
 fi

--- a/update.sh
+++ b/update.sh
@@ -47,7 +47,7 @@ sudo mv rhino-deinst /usr/bin
 
 # If the user has selected the option to install the mainline kernel, install it onto the system.
 if [[ -f "/usr/share/rhino/config/mainline" ]] && [[ ! -f "/usr/share/rhino/config/5-18-0" ]]; then
-    cd /usr/share//rhinoupdate/kernel/
+    cd /usr/share/rhinoupdate/kernel/
     wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.18/amd64/CHECKSUMS
     wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.18/amd64/linux-headers-5.18.0-051800-generic_5.18.0-051800.202205222030_amd64.deb
     wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.18/amd64/linux-headers-5.18.0-051800_5.18.0-051800.202205222030_all.deb


### PR DESCRIPTION
Basically this allows for a more sophisticated way to update **not** relying on users $HOME as this can also be problematic for multiple users. In the end this should allow for users to run rhino-update as sudo however this also allows to move away from bash aliases. If you really don't want to move update.sh to `/usr/bin/rhino-update` then it can be a system link to it which only requires sudo once to create.

- [x] convert local stuff to `/usr/share/rhino`
- [x] chmod `/usr/share/rhino` directory
- [x] make it use sudo for needed things
- [x] removing things like bash_aliases
- [ ] Use linking for RRR utils and rewrite the updating system on most utilities
- [ ] change way rhino utilities are updated
- [ ] move local files from ~ to `/usr/share/rhino`
