### PR TITLE
fix(update.sh): remove curl fix

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -57,13 +57,6 @@ fi
 
 # If Pacstall has been enabled
 if [[ -f "$HOME/.rhino/config/pacstall" ]]; then
-# Check to see whether an issue in Curl has been fixed
-  if [[ ! -f "$HOME/.rhino/config/curl-fix" ]]; then
-    sudo apt remove libcurl4 -y
-    sudo apt autoremove -y 
-    sudo apt install libcurl4 curl -y
-    : > "$HOME/.rhino/config/curl-fix"
-  fi
   # Install Pacstall
   mkdir -p ~/rhinoupdate/pacstall/
   cd ~/rhinoupdate/pacstall/


### PR DESCRIPTION
This fix isn't needed anymore as a newer version of curl has been released https://packages.ubuntu.com/kinetic/curl so for prebuilt RRR images this already has latest version and existing users can just update to newer version.