### PR TITLE
feat: rely on if snap is installed to update

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -50,7 +50,7 @@ if [[ -f "$HOME/.rhino/config/mainline" ]] && [[ ! -f "$HOME/.rhino/config/5-18-
 fi
 
 # If snapd is installed.
-if [[ ! -f "$HOME/.rhino/config/snapdpurge" ]]; then
+if [[ -f "/usr/bin/snap" ]]; then
   sudo snap refresh
 fi
 


### PR DESCRIPTION
rhino-update should rely on if snap is actually there are not - not a config file. Because if for example you forgot to use rhino-config -s but removed snap via apt then rhino-update would still try to update nonexistent `snap`.