### PR TITLE
Stick with standards for /etc/os-release

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -85,8 +85,7 @@ fi
 cd ~
 mkdir ~/rhinoupdate/system-files/
 git clone https://github.com/rollingrhinoremix/assets ~/rhinoupdate/system-files/
-sudo rm -rf /etc/os-release
-sudo mv ~/rhinoupdate/system-files/os-release /etc/
+sudo mv ~/rhinoupdate/system-files/os-release /usr/lib/
 
 # Allow the user to know that the upgrade has completed.
 echo "---


### PR DESCRIPTION
Don't delete symlinks and replace them with files.

Quoting os-release manpage:

> /usr/lib/os-release is the recommended place to store OS release
> information as part of vendor trees. /etc/os-release should be a relative symlink to
> /usr/lib/os-release, to provide compatibility with applications only looking at /etc/. A
> relative symlink instead of an absolute symlink is necessary to avoid breaking the link in
> a chroot or initrd environment such as dracut.