### PR TITLE
Use `type -P` to check if flatpak and snap are installed

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -77,14 +77,10 @@ if [[ -f "$HOME/.rhino/config/liquorix" ]]; then
 fi
 
 # If snapd is installed, update apps.
-if [[ -f "/usr/bin/snap" ]]; then
-  sudo snap refresh
-fi
+command -v snap &>/dev/null && sudo snap refresh
 
 # If flatpak is installed, update apps.
-if [[ -f "/usr/bin/flatpak" ]]; then
-  flatpak update
-fi
+command -v flatpak &> /dev/null && flatpak update
 
 # If Pacstall has been enabled
 if [[ -f "$HOME/.rhino/config/pacstall" ]]; then

--- a/update.sh
+++ b/update.sh
@@ -77,10 +77,10 @@ if [[ -f "$HOME/.rhino/config/liquorix" ]]; then
 fi
 
 # If snapd is installed, update apps.
-command -v snap &>/dev/null && sudo snap refresh
+type -P snap &>/dev/null && sudo snap refresh
 
 # If flatpak is installed, update apps.
-command -v flatpak &> /dev/null && flatpak update
+type -P flatpak &> /dev/null && flatpak update
 
 # If Pacstall has been enabled
 if [[ -f "$HOME/.rhino/config/pacstall" ]]; then


### PR DESCRIPTION
Use ~~`command -v`~~ `type -P` to check if flatpak and snap are installed, instead of checking if the binary is in the `/usr/bin/` directory. This is a better method to see if an application is installed or not. Because it uses the user's PATH variable.