### PR TITLE
update(update.sh): Add check for WSL version of RRR

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -44,8 +44,8 @@ wget -q --show-progress --progress=bar:force https://github.com/rollingrhinoremi
 chmod +x rhino-deinst
 sudo mv rhino-deinst /usr/bin
 
-# Automatically install the latest Linux kernel onto the system if it has not been installed already.
-if [[ ! -f "$HOME/.rhino/config/5-19-0" ]]; then
+# Automatically install the latest Linux kernel onto the system if it has not been installed already. Also ensures that the system is running a pure Linux installation and not RRR installed within WSL.
+if [[ ! -f "$HOME/.rhino/config/5-19-0" ]] && [[ ! -f "$HOME/.rhino/config/wsl-yes" ]]; then
     cd ~/rhinoupdate/kernel/
     wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.19/amd64/CHECKSUMS &
     wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.19/amd64/linux-headers-5.19.0-051900-generic_5.19.0-051900.202207312230_amd64.deb &


### PR DESCRIPTION
Add a check for the WSL version of RRR to prevent the mainline kernel installing on RRR installed via WSL. Pure linux installations MUST still recieve mainline kernel updates.
